### PR TITLE
Update Build Action and add manual Test action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 # Build BREXX/370
   build-brexx370:
-    name: Get tk4-jcc container
+    name: Building Brexx/370
     runs-on: [ubuntu-latest]
     container: mainframed767/tk4-jcc:latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,6 @@ jobs:
       run: |
         ./tests.sh > tests.jcl
         rdrprep tests.jcl
-        nc -w1 localhost 3505 < reader.jcl
+        nc -w1 localhost 3506 < reader.jcl
         ../build/rc.sh tests.jcl ../build/rc.sh tests.jcl 
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Test Brexx/370
+
+on: 
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: false
+        default: 'warning'
+
+jobs:
+# Test BREXX/370
+  test-brexx370:
+    name: Testing Brexx/370
+    runs-on: [ubuntu-latest]
+    container: mainframed767/tk4-jcc:latest
+
+    steps:
+    - name: Run tk4-
+      working-directory: /tk4-/
+      run: ./mvs >/dev/null 2>/dev/null &
+      
+    - name: Checkout
+      uses: actions/checkout@v2
+  
+    - name: Move Brexx
+      run: |
+        mkdir -p /brexx370/          
+        mv * /brexx370/
+      shell: bash
+  
+    - name: Wait for tk4-
+      working-directory: /
+      run: /tk4-/tk4_loaded.sh
+      shell: bash
+      
+    - name: Edit Makefile
+      working-directory: /brexx370/build
+      run: |
+        echo "REF:" ${{ github.ref }}
+        sed -i 's_../../tk4-test/prt/prt00e.txt_/tk4-/prt/prt00e.txt_' Makefile
+        sed -i 's/@$(JCC) $< >> jcc.log 2>&1/$(JCC) $</' Makefile
+        sed -i 's/SLEEP       := 25/SLEEP       := 15/' Makefile
+        sed -i 's_/usr/bin/bash_/bin/bash_' rc.sh
+      shell: bash
+      
+    - name: Build
+      working-directory: /brexx370/build
+      run: make
+      shell: bash
+
+    - name: Install
+      working-directory: /brexx370/build
+      run: make install
+      shell: bash
+      
+    - name: Test
+      working-directory: /brexx370/test
+      run: |
+        ./tests.sh > tests.jcl
+        rdrprep tests.jcl
+        nc -w1 localhost 3505 < reader.jcl
+        ../build/rc.sh tests.jcl ../build/rc.sh tests.jcl 
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,5 +61,5 @@ jobs:
         rdrprep tests.jcl
         nc -w1 localhost 3506 < reader.jcl
         sleep 15
-        ../build/rc.sh tests.jcl ../build/rc.sh tests.jcl 
+        ../build/rc.sh tests.jcl /tk4-/prt/prt00e.txt
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,6 @@ jobs:
         ./tests.sh > tests.jcl
         rdrprep tests.jcl
         nc -w1 localhost 3506 < reader.jcl
+        sleep 15
         ../build/rc.sh tests.jcl ../build/rc.sh tests.jcl 
       shell: bash


### PR DESCRIPTION
This fixes the name of the build job to be 'Building Brexx/370' instead of what it was before. 

This also adds testing automation using the new `test` folder. It runs manually using the "run workflow" under actions, Test. 

![image](https://user-images.githubusercontent.com/1973519/94645801-9eac1500-02a1-11eb-84c2-105b2a26ef56.png)
