### PR TITLE
Fixing bug in install.sh

### DIFF
--- a/build/clean.sh
+++ b/build/clean.sh
@@ -7,7 +7,7 @@ TYPE=""
 XMI_DIR=../mvs/install
 PDS="samples rxlib cmdlib"
 RELEASE_PDS="jcl samples rxlib cmdlib install proclib"
-VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}')
+VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}'|sed "s/[^[:alnum:]]//g" | tr a-z A-Z| cut -c 1-8)
 
 
 if [ $# = 1 ]; then

--- a/build/install.sh
+++ b/build/install.sh
@@ -10,7 +10,7 @@
 USER="HERC01"
 PASS="CUL8TR"
 CLASS="A"
-VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}')
+VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}'|sed "s/[^[:alnum:]]//g" | tr a-z A-Z| cut -c 1-8)
 XMI_DIR=../mvs/install
 
 BUILD_DATE=$(date +"%d %b %Y %T")

--- a/build/release.sh
+++ b/build/release.sh
@@ -3,7 +3,7 @@
 USER="HERC01"
 PASS="CUL8TR"
 CLASS="A"
-VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}')
+VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}'|sed "s/[^[:alnum:]]//g" | tr a-z A-Z| cut -c 1-8)
 XMI_DIR=../mvs/install
 
 BUILD_DATE=$(date +"%d %b %Y %T")

--- a/build/test.sh
+++ b/build/test.sh
@@ -6,7 +6,7 @@
 USER="HERC01"
 PASS="CUL8TR"
 CLASS="A"
-VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}')
+VERSION=$(grep "VERSION " ../inc/rexx.h|awk  '{gsub(/"/, "", $3); print $3}'|sed "s/[^[:alnum:]]//g" | tr a-z A-Z| cut -c 1-8)
 
 if [ $# = 1 ]; then
     USER=$1


### PR DESCRIPTION
Install.sh version check would accept any characters, leading to bad JCL being create. This update fixes it to follow dataset naming rules:

* alpha numeric only
* eight chars or less

Tested on docker image with the following results:

```
JCC-RC:0, Total Time:2ms
# prelinking JCC objects into brexx.objp
# Generating link job using  USER=HERC01 PASS=CUL8TR MSGCLASS=A
# Converting to EBCDIC
# Submiting  link job to reader at localhost:3506
# Sleeping for 15 seconds before checking job results
Time     Job  Num  Jobname    Stepname  Procstep  Program   Retcode
00.47.10 JOB    5  BRXLINK    BRXLNK              IEWL      RC= 0000
00.47.11 JOB    5  BRXLINK    LINKAUTH            IEWL      RC= 0000
00.47.11 JOB    5  BRXLINK    ALIASES             IKJEFT01  RC= 0000
# Installing Brexx/370 with USER=HERC01 PASS=CUL8TR MSGCLASS=A
# Converting to EBCDIC
# Submiting install job to reader at localhost:3506
# Sleeping for 15 seconds before checking job results
# Checking job results
Time     Job  Num  Jobname    Stepname  Procstep  Program   Retcode
00.47.28 JOB    6  BRXINSTL   BRDELETE            IDCAMS    RC= 0000
00.47.28 JOB    6  BRXINSTL   BRDELPRC            IKJEFT01  RC= 0000
00.47.28 JOB    6  BRXINSTL   BRCREATE            IEFBR14   RC= 0000
00.47.28 JOB    6  BRXINSTL   BRPROCLB            IEBUPDTE  RC= 0000
00.47.28 JOB    6  BRXINSTL   BRJCLLIB            IEBUPDTE  RC= 0000
00.47.28 JOB    6  BRXINSTL   BRSAMPLE            IEBUPDTE  RC= 0000
00.47.28 JOB    6  BRXINSTL   BRRXLIB             IEBUPDTE  RC= 0000
00.47.28 JOB    6  BRXINSTL   BRCMDLIB            IEBUPDTE  RC= 0000
```